### PR TITLE
Make send-region-or-current-line respect silent-cells

### DIFF
--- a/README.org
+++ b/README.org
@@ -116,7 +116,8 @@ C-c C-z     py-vterm-interaction-switch-to-repl-buffer
 
 C-c C-c     py-vterm-interaction-send-region-or-current-line
             Send the content of the region if the region is active, or send the current
-            line.
+            line. If the region is active and py-vterm-interaction-silent-cells is set to t
+            then the region is sent using ipython %run magic.
 
 C-c C-b     py-vterm-interaction-send-buffer
             Send the whole content of the script buffer to the Python REPL line by line.

--- a/py-vterm-interaction.el
+++ b/py-vterm-interaction.el
@@ -504,7 +504,7 @@ Otherwise, send the current line."
   (interactive)
   (if (use-region-p)
       (let ((str (buffer-substring-no-properties (region-beginning) (region-end))))
-        (py-vterm-interaction-paste-string str)
+        (py-vterm-interaction--send-maybe-silent str "region")
         (deactivate-mark))
     (py-vterm-interaction-send-current-line)))
 


### PR DESCRIPTION
Previously only cells and functions could be sent "silently".